### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ well as services created using Cloud Endpoints.
 - `Product Documentation`_
 
 .. |ga| image:: https://img.shields.io/badge/support-ga-gold.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#ga-support
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#ga-support
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-service-usage.svg
    :target: https://pypi.org/project/google-cloud-service-usage/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-service-usage.svg
@@ -81,4 +81,4 @@ Next Steps
    APIs that we cover.
 
 .. _Service Usage API Product documentation:  https://cloud.google.com/service-usage/docs
-.. _README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.