### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "serviceusage",
     "name_pretty": "Service Usage",
     "product_documentation": "https://cloud.google.com/service-usage",
-    "client_documentation": "https://googleapis.dev/python/serviceusage/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/serviceusage/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ well as services created using Cloud Endpoints.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-service-usage.svg
    :target: https://pypi.org/project/google-cloud-service-usage/
 .. _Service Usage: https://cloud.google.com/service-usage
-.. _Client Library Documentation: https://googleapis.dev/python/serviceusage/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/serviceusage/latest
 .. _Product Documentation:  https://cloud.google.com/service-usage/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.